### PR TITLE
[バグ修正] ポストするフィードの順序を pubDate ではなく、RSS feed の順序にする

### DIFF
--- a/src/getNewRssFeedItems.ts
+++ b/src/getNewRssFeedItems.ts
@@ -3,15 +3,16 @@ import RssParser  from 'rss-parser';
 type TechBlogRssFeedItem = {
   title: string;
   url: string;
-  pubDate: Date;
 }
 
 export async function getNewRssFeedItems(rssFeedUrl: string, lastPostedBlogUrl: string): Promise<Array<TechBlogRssFeedItem>> {
   const rssParser = new RssParser();
   const feed = await rssParser.parseURL(rssFeedUrl);
+
+  // 新着記事を抽出する
   let newTechBlogRssFeedItems: Array<TechBlogRssFeedItem> = [];
   for (const item of feed.items) {
-    if (item.link !== undefined && item.pubDate !== undefined) {
+    if (item.link !== undefined) {
       // Blueskyに投稿済みのブログ記事まで処理が進んだら、その時点で処理を終了する。
       if (item.link === lastPostedBlogUrl) {
         break;
@@ -19,10 +20,11 @@ export async function getNewRssFeedItems(rssFeedUrl: string, lastPostedBlogUrl: 
         newTechBlogRssFeedItems.push({
           title: item.title || "",
           url: item.link,
-          pubDate: new Date(item.pubDate)
         });
       }
     }
   }
-  return newTechBlogRssFeedItems;
+
+  // 新着記事を古い順にソートして返却
+  return newTechBlogRssFeedItems.reverse();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ async function postWithLinkCard(agent: BskyAgent, title: string, url: string): P
 }
 
 async function main() {
-  console.log(`[INFO] RSS_FEED_URL is ${process.env.RSS_FEED_URL}`)
+  console.log(`[INFO] RSS_FEED_URL: ${process.env.RSS_FEED_URL}`)
   if (process.env.RSS_FEED_URL === undefined) {
     console.error('[ERROR] finished because RSS_FEED_URL is undefined')
     return;
@@ -92,8 +92,6 @@ async function main() {
 
   // 新規のRSSフィードを取得する
   const newTechBlogRssFeedItems = await getNewRssFeedItems(process.env.RSS_FEED_URL, lastPostedBlogUrl)
-  newTechBlogRssFeedItems.sort((a, b) => a.pubDate.getTime() - b.pubDate.getTime());
-
   if (newTechBlogRssFeedItems.length === 0) {
     console.log('[DONE] finished because there are no new feeds.')
     return;


### PR DESCRIPTION
## 課題

**pubDate** が同じ値の場合、RSS フィードの順序とポストされる順序が不一致となることがある。

## 実現すること

新着記事について、RSSフィードの順序で（古いものから順に）ポストされること。

## テスト

- [x] **pubDate** が同じ値のフィードがあっても、RSSフィードの順序でポストされること。
